### PR TITLE
Don't call callbacks.Plugin.__init__ twice.

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -415,8 +415,6 @@ class Sigyn(callbacks.Plugin,plugins.ChannelDBHandler):
     noIgnore = True
     
     def __init__(self, irc):
-        self.__parent = super(Sigyn, self)
-        self.__parent.__init__(irc)
         callbacks.Plugin.__init__(self, irc)
         plugins.ChannelDBHandler.__init__(self)
         self._ircs = ircutils.IrcDict()


### PR DESCRIPTION
This is unnecessary, and I don't think that's a good idea to use super() if there are two parents anyway.
