### PR TITLE
fix unkline help text

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -764,7 +764,7 @@ class Sigyn(callbacks.Plugin,plugins.ChannelDBHandler):
     rmtmp = wrap(rmtmp,['op'])
 
     def unkline (self,irc,msg,args,nick):
-       """unkline <nick>
+       """<nick>
           request unkline of <nick>, klined recently from your channel
        """
        channels = []


### PR DESCRIPTION
Before:
```
<user> help unkline
<Sigyn> (unkline unkline <nick>) -- request unkline of <nick>, klined recently from your channel
```

After:
```
<user> help unkline
<Sigyn> (unkline <nick>) -- request unkline of <nick>, klined recently from your channel
```