### PR TITLE
plugin.py: fix using OperServ AKILL

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1009,7 +1009,7 @@ class Sigyn(callbacks.Plugin,plugins.ChannelDBHandler):
                           channels.append(channel)
                           if not isCloaked('%s!%s' % (nick,ip),self):
                               if self.registryValue('useOperServ'):
-                                  irc.sendMsg(ircmsgs.IrcMsg('PRIVMSG OperServ :DEL %s' % ip))
+                                  irc.sendMsg(ircmsgs.IrcMsg('PRIVMSG OperServ :AKILL DEL %s' % ip))
                               else:
                                   irc.queueMsg(ircmsgs.IrcMsg('UNKLINE %s' % ip))
                               if self.registryValue('clearTmpPatternOnUnkline',channel=channel):
@@ -1474,7 +1474,7 @@ class Sigyn(callbacks.Plugin,plugins.ChannelDBHandler):
             ## q.queue._P__slots__ probably
             self.log.info('KLINE %s|%s' % (mask,pending[3]))
             if self.registryValue('useOperServ'):
-                irc.sendMsg(ircmsgs.IrcMsg('PRIVMSG OperServ :ADD %s !T %s %s' % (mask,pending[2],pending[3])))
+                irc.sendMsg(ircmsgs.IrcMsg('PRIVMSG OperServ :AKILL ADD %s !T %s %s' % (mask,pending[2],pending[3])))
             else:
                 irc.sendMsg(ircmsgs.IrcMsg('KLINE %s %s :%s|%s' % (pending[2],mask,pending[4],pending[3])))
             for channel in irc.state.channels:
@@ -1514,7 +1514,7 @@ class Sigyn(callbacks.Plugin,plugins.ChannelDBHandler):
             else:
                 self.log.info('KLINE %s|%s' % (mask,reason))
                 if self.registryValue('useOperServ'):
-                    irc.sendMsg(ircmsgs.IrcMsg('PRIVMSG OperServ :ADD %s !T %s %s' % (mask,duration,reason)))
+                    irc.sendMsg(ircmsgs.IrcMsg('PRIVMSG OperServ :AKILL ADD %s !T %s %s' % (mask,duration,reason)))
                 else:
                     irc.sendMsg(ircmsgs.IrcMsg('KLINE %s %s :%s|%s' % (duration,mask,klineMessage,reason)))
                 if i.defcon:
@@ -2883,7 +2883,7 @@ class Sigyn(callbacks.Plugin,plugins.ChannelDBHandler):
                             q.reset()
                             uid = random.randint(0,1000000)
                             if self.registryValue('useOperServ'):
-                                irc.sendMsg(ircmsgs.IrcMsg('PRIVMSG OperServ :ADD %s !T %s %s' % (range,self.registryValue('klineDuration'),'%s - repeat abuses on this range (%s/%ss)' % (uid,permit,self.registryValue('ipv4AbuseLife')))))
+                                irc.sendMsg(ircmsgs.IrcMsg('PRIVMSG OperServ :AKILL ADD %s !T %s %s' % (range,self.registryValue('klineDuration'),'%s - repeat abuses on this range (%s/%ss)' % (uid,permit,self.registryValue('ipv4AbuseLife')))))
                             else:
                                 irc.sendMsg(ircmsgs.IrcMsg('KLINE %s *@%s :%s|%s' % (self.registryValue('klineDuration'),range,self.registryValue('klineMessage'),'%s - repeat abuses on this range (%s/%ss)' % (uid,permit,self.registryValue('ipv4AbuseLife')))))
                             self.logChannel(irc,"BAD: abuses detected on %s (%s/%ss - %s) %s" % (range,permit,self.registryValue('ipv4AbuseLife'),uid,','.join(hs)))


### PR DESCRIPTION
f35897a2d44e7f22a8d5dbdedc9c1b70f4891501 is missing the word or command
AKILL from the beginning of everything sent to OperServ.