### PR TITLE
Ignore flood snotes on freenode-connect

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -2580,7 +2580,7 @@ class Sigyn(callbacks.Plugin,plugins.ChannelDBHandler):
                     if i.defcon or len(queue) > 1:
                         for m in queue:
                             for q in m.split(','):
-                                if not ircdb.checkCapability(q, 'protected'):
+                                if not (ircdb.checkCapability(q, 'protected') or target == 'freenode-connect'):
                                     mask = self.prefixToMask(irc,q)
                                     uid = random.randint(0,1000000)
                                     self.kline(irc,q,mask,self.registryValue('klineDuration'),'%s - snote flood on %s' % (uid,target))


### PR DESCRIPTION
Sigyn keeps klining users for "flooding" freenode-connect when there's lots of new connections (and thus lots of CTCP replies going to freenode-connect). Ignore flood snotes about freenode-connect to prevent this.