### PR TITLE
"more than minimum users" means it's less than the minimum

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1778,7 +1778,7 @@ class Sigyn(callbacks.Plugin,plugins.ChannelDBHandler):
     def do322 (self,irc,msg):
         i = self.getIrc(irc)
         if msg.args[1] in i.invites:
-            if int(msg.args[2]) > self.registryValue('minimumUsersInChannel'):
+            if int(msg.args[2]) >= self.registryValue('minimumUsersInChannel'):
                 self.setRegistryValue('lastActionTaken',time.time(),channel=msg.args[1])
                 irc.queueMsg(ircmsgs.join(msg.args[1]))
                 try:


### PR DESCRIPTION
if `minimumUsersInChannel` is set to 20, this means the `LIST` output needs to show the channel as 21 users for it to be greater than `minimumUsersInChannel`. this fixes it to be `>=` instead of `>`.